### PR TITLE
fixed error on creating missing output dir

### DIFF
--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -130,17 +130,17 @@ int main(int argc, char **argv) {
         exit(0);
     }
 
+    struct stat sb;
+    if (stat(outputPath.c_str(), &sb) != 0 || !S_ISDIR(sb.st_mode)) {
+        mkdir(outputPath.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
+    }
+
     std::stringstream idMapFile;
     idMapFile << outputPath << "/id_mapping_" << runID << ".nc";
     m->saveNodeIdMapping(idMapFile.str());
 
     std::stringstream ss;
     ss << outputPath << "/output_" << runID << ".nc";
-
-    struct stat sb;
-    if (stat(outputPath.c_str(), &sb) != 0 || !S_ISDIR(sb.st_mode)) {
-        mkdir(outputPath.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
-    }
     std::cout << "Sample data will be saved to " << ss.str() << std::endl;
 
     void (*prevHandler)(int);


### PR DESCRIPTION
This error was introduced in the recent commit that writes the new node id mapping file. The missing directory check needs to occur prior to the new file write.